### PR TITLE
add url, function and schema for call to get units in stake

### DIFF
--- a/church_of_jesus_christ_api/church_of_jesus_christ_api.py
+++ b/church_of_jesus_christ_api/church_of_jesus_christ_api.py
@@ -87,6 +87,7 @@ _endpoints = {
     "unit-organizations": _host("lcr")
     + "/services/orgs/sub-orgs-with-callings?unitNumber={unit}",
     "user": _host("wam-membertools-api") + "/api/v4/user",
+    "units": _host("directory") + "/api/v4/units/{unit}",
 }
 
 
@@ -750,3 +751,20 @@ class ChurchOfJesusChristAPI(object):
         """
 
         return self.__get_JSON(self.__endpoint("statistics", unit=unit))
+
+    def get_units(self, unit: int = None) -> JSONType:
+        """
+        Returns information about the stake and it's child units
+
+        Parameters
+
+        unit : int
+            Number of the church unit for which to retrieve the data
+
+        Returns
+
+        .. literalinclude:: ../JSON_schemas/get_units-schema.md
+        """
+
+        return self.__get_JSON(self.__endpoint("units", unit=unit))
+

--- a/doc/source/JSON_schemas/units-schema.md
+++ b/doc/source/JSON_schemas/units-schema.md
@@ -1,0 +1,12 @@
+{
+  unitNumber: int,
+  unitType: str,
+  name: str,
+  childUnits: [
+    {
+      unitNumber: int,
+      unitType: str,
+      name: str
+    }
+  ]
+}


### PR DESCRIPTION
First, I don't work with GitHub much, so I'm not sure what the normal way to to a Fork/PR here is, if this is wrong, I'm sorry. Let me know how to change it and I will.

It currently isn't working for me. When I call:
api.get_units(parentUnitNumber)

It gives me an error:
Error from server: 401 - b'' for endpoint https://directory.churchofjesuschrist.org/api/v4/units/MY_STAKE_UNIT_NUMBER